### PR TITLE
Add dynamic pilot name parsing

### DIFF
--- a/aerofiles/igc/reader.py
+++ b/aerofiles/igc/reader.py
@@ -371,7 +371,7 @@ class LowLevelReader:
 
     @staticmethod
     def decode_H_pilot(line):
-        pilot = line[19:].strip()
+        pilot = line[line.find(':') + 1:].strip()
         return {'pilot': None} if pilot == '' else {'pilot': pilot}
 
     @staticmethod

--- a/tests/igc/test_reader.py
+++ b/tests/igc/test_reader.py
@@ -181,6 +181,24 @@ def test_decode_H_pilot():
     assert LowLevelReader.decode_H_pilot(line) == expected_result
 
 
+def test_decode_H_pilot_pwca_header():
+    line = 'HFPLTPILOT: Bloggs Bill D\r\n'
+    expected_result = {
+        'pilot': 'Bloggs Bill D'
+    }
+
+    assert LowLevelReader.decode_H_pilot(line) == expected_result
+
+
+def test_decode_H_pilot_unkown_header():
+    line = 'HFPLT XXX : Bloggs Bill D\r\n'
+    expected_result = {
+        'pilot': 'Bloggs Bill D'
+    }
+
+    assert LowLevelReader.decode_H_pilot(line) == expected_result
+
+
 def test_decode_H_copilot():
     line = 'HFCM2CREW2: Smith-Barry John A\r\n'
     expected_result = {


### PR DESCRIPTION
Hi,

Some task validation software such as the one used by the PWCA appears to be slightly changing the IGC headers format. This results in a wrong parsing of the pilot's name when reading IGC files validated by such software.

As an example, PWCA uses HFPLTPILOT field rather than HFPLTPILOTINCHARGE, leading to an incorrect slice of the name in the low level reader. The change proposed allows a dynamic slicing of this field in order to handle correctly various IGC header formats.

GpsDump also seems to be using HFPLTPILOT rather than HFPLTPILOTINCHARGE.
