### PR TITLE
seeyou/reading: Allow more than 11 fields

### DIFF
--- a/aerofiles/seeyou/reader.py
+++ b/aerofiles/seeyou/reader.py
@@ -81,7 +81,6 @@ class Reader:
         if num_fields > 13:
             raise ParserError('Too many fields provided. Expecting at maximum following 13 fileds:\nname,code,country,lat,lon,elev,style,rwdir,rwlen,freq,desc,userdata,pics')
 
-            
         fields = [field.strip() for field in fields]
 
         return {

--- a/aerofiles/seeyou/reader.py
+++ b/aerofiles/seeyou/reader.py
@@ -75,9 +75,13 @@ class Reader:
         if fields[0].startswith('*'):
             return
 
-        if num_fields != 11:
-            raise ParserError('Fields are missing')
+        if num_fields < 11:
+            raise ParserError('Not enough fields provided. Expecting at minimum following 11 fileds:\nname,code,country,lat,lon,elev,style,rwdir,rwlen,freq,desc')
 
+        if num_fields > 13:
+            raise ParserError('Too many fields provided. Expecting at maximum following 13 fileds:\nname,code,country,lat,lon,elev,style,rwdir,rwlen,freq,desc,userdata,pics')
+
+            
         fields = [field.strip() for field in fields]
 
         return {


### PR DESCRIPTION
Updates sanity checks on field length of cup files.
SeeYou V10.32 outputs cup-files with following fields:
name,code,country,lat,lon,elev,style,rwdir,rwlen,freq,desc,userdata,pics

Here is the Naviter CUP-file format description, which is unfortunately outdated and does not mention the last two fields.
http://download.naviter.com/docs/CUP-file-format-description.pdf