### PR TITLE
Made parsing of .cup files more generic regarding headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ coverage.xml
 docs/_build/
 
 tests/welt2000/data/WELT2000.TXT
+
+# Mac
+*.DS_STORE

--- a/aerofiles/seeyou/reader.py
+++ b/aerofiles/seeyou/reader.py
@@ -76,7 +76,7 @@ class Reader:
         reader = csv.reader(fp)
         headers = next(reader, [])
         if not all(h in headers for h in BASE_HEADERS):
-            raise ParserError(f"Headers must include {BASE_HEADERS}")
+            raise ParserError("Headers must include at least include name, code, country, lat, lon, elev, style")
 
         for fields in reader:
             if fields == ["-----Related Tasks-----"]:
@@ -116,16 +116,14 @@ class Reader:
 
         if num_fields < len(BASE_HEADERS):
             raise ParserError(
-                f"Not enough fields provided. Expecting at minimum following fields: {BASE_HEADERS}"
+                "Not enough fields provided. Expecting at minimum following fields: \nname, code, country, lat, lon, elev, style"
             )
 
         if num_fields > len(BASE_HEADERS) + len(PLUS_HEADERS):
-            raise ParserError(
-                f"Too many fields provided. Expecting at maximum following 14 fields: {BASE_HEADERS + PLUS_HEADERS}"
-            )
+            raise ParserError("Too many fields provided. Expecting at maximum following 14 fields")
 
         return {
-            MAPPING[h]: getattr(self, f"decode_{MAPPING[h]}")(field.strip())
+            MAPPING[h]: getattr(self, "decode_%s" % MAPPING[h])(field.strip())
             for h, field in zip(headers, fields)
             if MAPPING.get(h)
         }

--- a/tests/seeyou/data/task_container.cup
+++ b/tests/seeyou/data/task_container.cup
@@ -1,0 +1,13 @@
+name,code,country,lat,lon,elev,style,rwdir,rwlen,rwwidth,freq,desc,userdata,pics
+"CUW_1",CUW_1,,5004.298N,00757.516E,443.0m,1,,,,,,,
+"CUW_2",CUW_2,,4928.697N,00646.924E,346.0m,1,,,,,,,
+"CUW_3",CUW_3,,4934.661N,01017.803E,386.0m,1,,,,,,,
+"CUW_4",CUW_4,,5051.797N,00944.636E,277.0m,1,,,,,,,
+"CUW_5",CUW_5,,5004.298N,00757.516E,443.0m,1,,,,,,,
+-----Related Tasks-----
+"TSK 664.7 / 664.7 Triangle","???","CUW_1","CUW_2","CUW_3","CUW_4","CUW_5","???"
+ObsZone=0,Style=2,R1=1000m,A1=45,SpeedStyle=1
+ObsZone=1,Style=1,R1=1000m,A1=45,SpeedStyle=1
+ObsZone=2,Style=1,R1=1000m,A1=45,SpeedStyle=1
+ObsZone=3,Style=1,R1=1000m,A1=45,SpeedStyle=1
+ObsZone=4,Style=3,R1=1000m,A1=45,SpeedStyle=1

--- a/tests/seeyou/test_reader.py
+++ b/tests/seeyou/test_reader.py
@@ -10,6 +10,7 @@ from tests import assert_waypoint
 FOLDER = path.dirname(path.realpath(__file__))
 DATA_PATH = path.join(FOLDER, 'data', 'SEEYOU.CUP')
 SIMPLE_CUPFILE = path.join(FOLDER, 'data', 'simple.cup')
+CLOUD_CUPFILE = path.join(FOLDER, 'data', 'task_container.cup')
 
 if_data_available = pytest.mark.skipif(
     not path.exists(DATA_PATH),
@@ -329,6 +330,9 @@ def test_read():
         waypoints = Reader().read(f)['waypoints']
         for i, waypoint in enumerate(waypoints):
             assert_waypoint(waypoint, WAYPOINTS[i][1])
+
+    with open(CLOUD_CUPFILE) as f:
+        waypoints = Reader().read(f)['waypoints']
 
 
 def check_waypoint(waypoint):


### PR DESCRIPTION
I had problems parsing a cup file downloaded from SeeYou cloud as the header rwwidth was included. Parsing now ignores columns that are not specified instead of throwing an error. 

Sorry for the double quotes, this is due to auto formatting with black.