### PR TITLE
seeyou/reader: Use `style: 0` for unknown waypoint types

### DIFF
--- a/aerofiles/seeyou/reader.py
+++ b/aerofiles/seeyou/reader.py
@@ -171,7 +171,7 @@ class Reader:
             raise ParserError('Reading style failed')
 
         if not (1 <= style <= 17):
-            raise ParserError('Unknown waypoint style')
+            style = 0
 
         return style
 

--- a/tests/seeyou/test_reader.py
+++ b/tests/seeyou/test_reader.py
@@ -297,6 +297,16 @@ def test_decode_distance():
 
     with pytest.raises(ParserError):
         Reader().decode_distance('12a50m')
+        
+        
+def test_decode_style():
+    assert Reader().decode_style('10') == 10
+    assert Reader().decode_style('0') == 0
+    assert Reader().decode_style('20') == 0
+   
+
+    with pytest.raises(ParserError):
+        Reader().decode_style('u')
 
 
 @pytest.fixture(params=WAYPOINTS)

--- a/tests/seeyou/test_reader.py
+++ b/tests/seeyou/test_reader.py
@@ -304,7 +304,6 @@ def test_decode_style():
     assert Reader().decode_style('0') == 0
     assert Reader().decode_style('20') == 0
    
-
     with pytest.raises(ParserError):
         Reader().decode_style('u')
 


### PR DESCRIPTION
The specification states:

"Waypoint style describes the type of the waypoint. If a value other than the ones listed below is found in the file the parser should default it to 0."

Also, 0 is mentioned as a valid value ("unknown")