### PR TITLE
Make parsing of Options / ObsZone case insensitive

### DIFF
--- a/aerofiles/seeyou/reader.py
+++ b/aerofiles/seeyou/reader.py
@@ -40,9 +40,9 @@ class Reader:
                 task_information = True
                 continue
             if task_information:
-                if fields[0] == 'Options':
+                if fields[0].lower() == 'options':
                     tasks[-1]['Options'] = self.decode_task_options(fields)
-                elif fields[0].startswith('ObsZone'):
+                elif fields[0].lower().startswith('obszone'):
                     tasks[-1]['obs_zones'].append(self.decode_task_obs_zone(fields))
                 else:
                     tasks.append(

--- a/tests/seeyou/data/simple.cup
+++ b/tests/seeyou/data/simple.cup
@@ -12,8 +12,8 @@ name,code,country,lat,lon,elev,style,rwdir,rwlen,freq,desc
 -----Related Tasks-----
 "3 turnpoints","Meiersberg","Meiersberg","Vettweiss Soller","Weisweiler Kw 10","Eddln0 Eddl N P","Meiersberg","Meiersberg"
 Options,TaskTime=03:00:00,WpDis=True,MinDis=True,RandomOrder=False,MaxPts=13,NearDis=0.7km,NearAlt=300.0m
-ObsZone=0,Style=2,R1=2500m,Line=1
-ObsZone=1,Style=1,R1=500m,A1=180
+OBSZONE=0,Style=2,R1=2500m,Line=1
+obszone=1,Style=1,R1=500m,A1=180
 ObsZone=2,Style=1,R1=500m,A1=180
 ObsZone=3,Style=1,R1=2000m,A1=180
 ObsZone=4,Style=3,R1=500m,Line=1


### PR DESCRIPTION
There exist files where Options is printed in UpperCase. We should be able to parse these.