### PR TITLE
'HFGPS' is replaced by 'HFGPSRECEIVER:' to comply with section A3.2.4 of current IGC specs

### DIFF
--- a/aerofiles/igc/writer.py
+++ b/aerofiles/igc/writer.py
@@ -295,7 +295,7 @@ class Writer:
 
         :param gps_receiver: the GPS receiver information
         """
-        self.write_fr_header('GPS', gps_receiver)
+        self.write_fr_header('GPS', gps_receiver, subtype_long='RECEIVER')
 
     def write_pressure_sensor(self, pressure_sensor):
         """


### PR DESCRIPTION
There were some discrepancy is the IGC specs in past, which was explained earlier in the Issues section:
https://github.com/Turbo87/aerofiles/issues/18#issue-141241207

However, it looks like IGC group has fixed that already. And most of modern FR equipment is using a complete HFGPSRECEIVER token at this time.

For details, please, take a look at page 26 of http://www.ukiws.uk/GFAC/documents/tech_spec_gnss.pdf