### PR TITLE
seeyou: Refine error message for unsupported taskpoint keys

### DIFF
--- a/aerofiles/seeyou/reader.py
+++ b/aerofiles/seeyou/reader.py
@@ -312,7 +312,7 @@ class Reader:
             elif field_type == 'Reduce' and field_entry == "1":
                 task_obs_zone['reduce'] = True
             else:
-                raise Exception('A taskpoint does not contain key %s' % field_type)
+                raise Exception('A taskpoint may not contain key %s' % field_type)
 
         return task_obs_zone
 


### PR DESCRIPTION
When a cup file contains a taskpoint with an unknown key,
the error was "A taskpoint does not contain key AAT",
which is unfortunately badly worded.

The intention is more accurately "A taskpoint may not contain key AAT".
source:

https://github.com/XCSoar/xcsoar-data-content/pull/135#issuecomment-812756198