### PR TITLE
Docs: Add aerofiles module path to PATH.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,7 @@ import os
 sys.path.append(os.path.abspath('_themes'))
 sys.path.append(os.path.abspath('_themes_flask'))
 sys.path.append(os.path.abspath('.'))
+sys.path.append(os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
Hi Turbo,

I was unable to build the docs, because the aerofiles modules were not available in sphinx, which produces the following error / warning:

```shell
WARNING: autodoc: failed to import class 'flarmcfg.Writer' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.flarmcfg'
WARNING: autodoc: failed to import module 'igc' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.igc'
WARNING: autodoc: failed to import class 'igc.Reader' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.igc'
WARNING: autodoc: failed to import class 'igc.Writer' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.igc'
WARNING: autodoc: failed to import class 'openair.Reader' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.openair'
WARNING: autodoc: failed to import class 'openair.LowLevelReader' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.openair'
WARNING: autodoc: failed to import class 'seeyou.Reader' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.seeyou'
WARNING: autodoc: failed to import class 'seeyou.Writer' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.seeyou'
WARNING: autodoc: failed to import class 'welt2000.Reader' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.welt2000'
WARNING: autodoc: failed to import class 'xcsoar.Writer' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.xcsoar'
WARNING: autodoc: failed to import module 'xcsoar.constants' from module 'aerofiles'; the following exception was raised:
No module named 'aerofiles.xcsoar'
```

This PR add the `docs` parent folder to the PATH variable, which includes the `aerofiles` python module, and thus, solves the issues above.

I was looking online for documentation on the `IGCReader` class, but couldn't find any.
As #137 points out, the latest docs are not (yet) deployed to readthedocs.org, maybe it is time for an update? ;-)

Best,
Sebastian