### PR TITLE
Alternate date fix #175

### DIFF
--- a/aerofiles/igc/reader.py
+++ b/aerofiles/igc/reader.py
@@ -363,6 +363,9 @@ class LowLevelReader:
     @staticmethod
     def decode_H_utc_date(line):
         date_str = line[5:11]
+        # Some IGC file have an alternate syntax for the date: instead of HFDTE280709, it uses HFDTEDATE:280709,01
+        if date_str.startswith('DATE'):
+            date_str = line[10:16]
         return {'utc_date': LowLevelReader.decode_date(date_str)}
 
     @staticmethod

--- a/tests/igc/test_reader.py
+++ b/tests/igc/test_reader.py
@@ -172,6 +172,15 @@ def test_decode_H_utc_date():
     assert LowLevelReader.decode_H_utc_date(line) == expected_result
 
 
+def test_decode_H_utc_date_alternate():
+    line = 'HFDTEDATE:160701,01\r\n'
+    expected_result = {
+        'utc_date': datetime.date(2001, 7, 16)
+    }
+
+    assert LowLevelReader.decode_H_utc_date(line) == expected_result
+
+
 def test_decode_H_pilot():
     line = 'HFPLTPILOTINCHARGE: Bloggs Bill D\r\n'
     expected_result = {


### PR DESCRIPTION
 Some IGC file have an alternate syntax for the date: instead of HFDTE280709, it uses HFDTEDATE: 280709,01