### PR TITLE
flymaster date H record fix - reading 6 characters from the end of the line

### DIFF
--- a/aerofiles/igc/reader.py
+++ b/aerofiles/igc/reader.py
@@ -362,7 +362,7 @@ class LowLevelReader:
 
     @staticmethod
     def decode_H_utc_date(line):
-        date_str = line[5:11]
+        date_str = line[-7:-1]
         return {'utc_date': LowLevelReader.decode_date(date_str)}
 
     @staticmethod


### PR DESCRIPTION
not sure if this is something you want to incorporate.
IGC files produced buy flymaster have the header in this format:

```
AXFI112255
HFDTEDATE:110823
HFPLTPILOTINCHARGE:Pawel Olas
HFCM2CREW2:NIL
HFGTYGLIDERTYPE:NKN
HFGIDGLIDERID:NKN
HFDTMGPSDATUM:WGS84
HFRFWFIRMWAREVERSION:2.11a
HFRHWHARDWAREVERSION:1.0
```

your code assumed that the date is after the DTE code but in this case there is DTEDATE key. I changed the code to read the date from the end of the line rather than assuming which characters are the date. probably regex here would be a much better choice but I opted for a simple fix that is in line with the rest of the code.
feel free to reject this pull request as I have no idea how this may affect other ICG tracks.