### PR TITLE
Bug fixed in seeyou.writer.Writer

### DIFF
--- a/aerofiles/seeyou/writer.py
+++ b/aerofiles/seeyou/writer.py
@@ -106,7 +106,7 @@ class Writer:
     def format_pics(self, pics):
         if pics is None or pics == []:
             return u''
-        return self.escape(','.join(pics))
+        return self.escape(';'.join(pics))
 
     def format_time(self, time):
         if isinstance(time, datetime.datetime):


### PR DESCRIPTION
multiple pics are only working when filenames are separated by semicolon instead of colon (Naviter cup file doc erroneous). Tested with LX9000 and Oudie