### PR TITLE
proposal for skip functionality

### DIFF
--- a/aerofiles/igc/reader.py
+++ b/aerofiles/igc/reader.py
@@ -17,11 +17,12 @@ class Reader:
     def __init__(self):
         self.reader = None
 
-    def read(self, file_obj):
+    def read(self, file_obj, skip_duplicates = False):
         """
         Read the specified file object and return a dictionary with the parsed data.
 
         :param file_obj: a Python file object
+        :param skip_duplicates: if True, entries with the same time stamp are skipped
 
         """
         self.reader = LowLevelReader(file_obj)


### PR DESCRIPTION
This very minimal PR is meant to start the conversation and hear about if you would approve an addition to the IGC reader class. I propose to add a `skip_duplicates` optional argument, which would skip fix records when they contain the same time stamp as those before, leaving only the first one.

Some IGC's contain duplicate fix records (same timestamp), making it annoying to handle them in downstream packages/programs. This gets problematic for instance when performing calculations based on the time difference between fixes. This time difference being 0 is then problematic. See this issue as example: https://github.com/GliderGeek/opensoar/issues/50.

Adding this here would simplify downstream code and prevent an extra loop over all the entries.